### PR TITLE
Fix requirements.txt

### DIFF
--- a/cwod_site/requirements.txt
+++ b/cwod_site/requirements.txt
@@ -1,29 +1,37 @@
+--allow-external pygooglechart
+--allow-unverified pygooglechart
+
+-e git+https://github.com/dvogel/django-postmark.git@410c4e21460b34fbd02634c84fa2e20824aa28ed#egg=django_postmark-master
+-e git+https://github.com/sunlightlabs/django-locksmith.git@f5b3731445735d1f79e8264ba4a9ca4c20eb85eb#egg=django_locksmith-master
+-e hg+https://dandrinkard@bitbucket.org/schinckel/django-jsonfield@ab026e78869b9be8f2d961a3e9a1730ae46cbc6d#egg=django_jsonfield-0.9.0
+argparse==1.1
 BeautifulSoup==3.2.0
-Django==1.3
-MySQL-python==1.2.3
-PyYAML==3.11
-argparse==1.2.1
 boto==2.0
-distribute>=0.6.21
 django-debug-toolbar==0.8.5
--e hg+https://bitbucket.org/schinckel/django-jsonfield@0.7.1#egg=django_jsonfield-dev
--e git+https://github.com/sunlightlabs/django-locksmith.git#egg=django_locksmith-0.5.0
 django-mediasync==2.2.0
-django-piston==0.2.2
--e git+https://github.com/dvogel/django-postmark.git#egg=django_postmark-dev
-django-typogrify==1.2.2
-gunicorn
-httplib2
+django-piston==0.2.3
+django-typogrify==1.3
+Django==1.3
+gunicorn==0.12.0
+httplib2==0.7.3
 ipython==0.10.1
-lxml==2.3
+lxml==2.3beta1
+Markdown==2.3.1
 mimeparse==0.1.3
-markdown
+MySQL-python==1.2.3
 name-tools==0.1.2
-nltk>=2.0
+nltk==2.0.1
 numpy==1.8.0
--e git+https://github.com/gak/pygooglechart.git#egg=pygooglechart-dev
+pygooglechart==0.4.0
+pymongo==1.9
 python-dateutil==1.5
-python-memcached
+python-memcached==1.53
 python-sunlightapi==1.0.0
-
-
+pytz==2013.9
+PyYAML==3.10
+scipy==0.13.3
+simplejson==3.3.2
+six==1.5.2
+smartypants==1.8.3
+textile==2.1.5
+wsgiref==0.1.2

--- a/readme
+++ b/readme
@@ -1,9 +1,7 @@
 useful info goes here
 
 Requirements
-* json or simplejson
-* beautifulsoup verion 3.0 series (it MUST be 3.0 series, not 3.1)
-  http://www.crummy.com/software/BeautifulSoup/download/3.x/BeautifulSoup-3.0.8.1.tar.gz
+* see cwod_site/requirements.txt for python package requirements
 * solr
 * sunlightlabs API key
 


### PR DESCRIPTION
Follow up after my old pull request: https://github.com/sunlightlabs/Capitol-Words/pull/73

fix requirements.txt to allow future developers to simply `pip install -r requirements.txt`.
