### PR TITLE
Fix settings.example.py

### DIFF
--- a/settings.example.py
+++ b/settings.example.py
@@ -7,9 +7,15 @@ TMP_DIR = '/tmp/'
 LOG_DIR = os.path.join(CWOD_HOME, 'log')
 
 # how far back in time does the system check for congressional record
-# documents? dd/mm/yyyy format. 
-OLDEST_DATE = '01/06/2010'
+# documents? dd/mm/yyyy format.
+OLDEST_DATE = '01/1/1994' # oldest date in system is around 1/25/1994
 # where should the scraper log the files it's downloaded?
 SCRAPER_LOG = os.path.join(LOG_DIR, 'scraper.log')
 # what domain and port are solr listening on?
 SOLR_DOMAIN = 'http://localhost:8983'
+
+CWOD_HOME = "" # directory where data is downloaded, parsed, and ingested from
+TMP_DIR = 'tmp/'
+DB_PARAMS = ["localhost","username","password","capitolwords"]
+DB_PATH = "" # path to api/capitolwords sqlite database
+BIOGUIDE_LOOKUP_PATH = "" # path to api/bioguide_lookup.csv


### PR DESCRIPTION
Add some variables to settings.example.py that are expected throughout the code.

```
CWOD_HOME = "" # directory where data is downloaded, parsed, and ingested from
TMP_DIR = 'tmp/'
DB_PARAMS = ["localhost","username","password","capitolwords"]
DB_PATH = "" # path to api/capitolwords sqlite database
BIOGUIDE_LOOKUP_PATH = "" # path to api/bioguide_lookup.csv
```

I found that the code wouldn't run until these variables were at least defined. In addition, because these files are symlinked (as per the README) to the various subdirectories I couldn't come up with a single snippet of code that could properly set CWOD_HOME, DB_PATH, and BIOGUIDE_LOOK_PATH depending on where the file was being called referred to from. This is why I just left them as empty quotes and put a comment as to what it should be.
