### PR TITLE
Fix parser where 'Pgnull' is in filename

### DIFF
--- a/parser/parser.py
+++ b/parser/parser.py
@@ -379,6 +379,7 @@ class CRParser(object):
 
         try:
             pagenums = re.search(r'(Pg.*)', granule).groups()[0]
+            if pagenums.find("Pgnull") != -1: raise AttributeError
         except AttributeError, IndexError:
             print '%s does not contain any page numbers' % granule
             return


### PR DESCRIPTION
Added check in parser to see if filename has "Pgnull" because parser currently fails on these files. There are about 10 such files cumulatively in 1994 and 1995.
