### PR TITLE
Prevent need to symlink settings.py

### DIFF
--- a/parser/parser.py
+++ b/parser/parser.py
@@ -6,6 +6,10 @@ import re, datetime, os, sys
 from cStringIO import StringIO
 import urllib2
 from xml.sax.saxutils import escape, unescape
+
+import site
+ROOT = os.path.dirname(os.path.realpath(__file__))
+site.addsitedir(os.path.join(ROOT, "../"))
 from settings import CWOD_HOME, LOG_DIR
 
 import lxml.etree

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -2,12 +2,15 @@
 
 import urllib, urllib2, os, datetime, re, sys, httplib, zipfile
 import time
-from settings import *
 try:
     import json
 except:
     import simplejson as json
 
+import site
+ROOT = os.path.dirname(os.path.realpath(__file__))
+site.addsitedir(os.path.join(ROOT, "../"))
+from settings import *
 
 class CRScraper(object):
     def __init__(self):

--- a/solr/api.py
+++ b/solr/api.py
@@ -5,7 +5,12 @@ returning nicely formatted statistics.  '''
 
 import datetime
 import urllib, urllib2, sys, os
+
+import site
+ROOT = os.path.dirname(os.path.realpath(__file__))
+site.addsitedir(os.path.join(ROOT, "../"))
 import settings
+
 try:
     import json
 except:

--- a/solr/ingest.py
+++ b/solr/ingest.py
@@ -12,7 +12,12 @@ from xml.sax.saxutils import escape, unescape
 from xml.parsers.expat import ExpatError
 import sys, os, re
 from lib import bioguide_lookup, db_bioguide_lookup, fallback_bioguide_lookup
+
+import site
+ROOT = os.path.dirname(os.path.realpath(__file__))
+site.addsitedir(os.path.join(ROOT, "../"))
 from settings import *
+
 import datetime
 
 import lxml.etree

--- a/solr/lib.py
+++ b/solr/lib.py
@@ -2,6 +2,9 @@
 
 ''' useful supporting functions '''
 
+import os, site
+ROOT = os.path.dirname(os.path.realpath(__file__))
+site.addsitedir(os.path.join(ROOT, "../"))
 from settings import API_KEY, DB_PATH, BIOGUIDE_LOOKUP_PATH, DB_PARAMS
 
 from BeautifulSoup import BeautifulSoup


### PR DESCRIPTION
Essentially add the following snippet of code to the top of the parser, ingestor, and scraper to prevent need for symlinking settings.py.

```
import os, site
ROOT = os.path.dirname(os.path.realpath(__file__))
site.addsitedir(os.path.join(ROOT, "../"))
```

This will allow settings.py to calculate the path to the sqlite database, the csv, and other files relative to the repository.

As an example my settings.py looks like this after this PR:

```
CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
DB_PATH = os.path.join(CURRENT_DIR, 'api/capitolwords.db')
BIOGUIDE_LOOKUP_PATH = os.path.join(CURRENT_DIR, 'api/bioguide_lookup.csv')

CWOD_HOME = os.path.join(CURRENT_DIR, 'data/cr')
LOG_DIR = os.path.join(CWOD_HOME, 'log')
SCRAPER_LOG = os.path.join(LOG_DIR, 'scraper.log')
```
