### PR TITLE
Fix hashbang on python scripts

### DIFF
--- a/capitolwords.py
+++ b/capitolwords.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 '''
 The main loop for Capitol Words, run daily. 

--- a/parser/parser.py
+++ b/parser/parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 ''' Parse the plain text version of congressional record documents and mark them up with xml.'''
 

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import urllib, urllib2, os, datetime, re, sys, httplib, zipfile
 import time

--- a/solr/api.py
+++ b/solr/api.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 ''' A set of functions that give specific views into the solr documents,
 returning nicely formatted statistics.  '''

--- a/solr/ingest.py
+++ b/solr/ingest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 ''' Takes XML-annotated CR documents and turns them into solr documents. The
 primary difference is that solr expects fields to be in a different format, and

--- a/solr/lib.py
+++ b/solr/lib.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 ''' useful supporting functions '''
 


### PR DESCRIPTION
Convert `#!/usr/bin/python` to `#!/usr/bin/env python` at the top of all python scripts. 

> Running a command through /usr/bin/env has the benefit of looking for whatever the default version of the program is in your current environoment.

source: http://stackoverflow.com/questions/16365130/the-difference-between-usr-bin-env-bash-and-usr-bin-bash
