### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/capitolweb/parser/crec_parser.py
+++ b/capitolweb/parser/crec_parser.py
@@ -11,7 +11,7 @@ import boto3
 import spacy
 import textacy
 from lxml import etree
-from fuzzywuzzy import process
+from rapidfuzz import process
 from django.utils.functional import cached_property
 from django.conf import settings
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ fabric==2.3.1
 freezegun==0.3.9
 ftfy==4.4.3
 future==0.16.0
-fuzzywuzzy==0.17.0
+rapidfuzz==0.2.1
 gunicorn==19.9.0
 html5lib==1.0.1
 idna==2.7
@@ -66,7 +66,6 @@ pyemd==0.5.1
 PyNaCl==1.2.1
 Pyphen==0.9.5
 python-dateutil==2.7.3
-python-Levenshtein==0.12.0
 pytz==2017.2
 PyYAML==3.13
 regex==2017.4.5


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.